### PR TITLE
Update Copilot setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,5 @@
 name: Copilot Setup Steps
+
 on:
   workflow_dispatch:
   push:
@@ -10,9 +11,9 @@ on:
 
 jobs:
   copilot-setup-steps:
-    # Der Copilot Coding Agent erwartet exakt diesen Jobnamen.
+    # The Copilot agent expects this exact job id.
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: 45
     permissions:
       contents: read
 
@@ -20,85 +21,62 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: "1"
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
       APP_ENV: "CI"
-      # Eigene Feature Flags oder Konfigurationsschalter:
-      # VL_NATIVE_MODE: "enabled"
-      # SKIA_SHARP_MODE: "default"
+
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: ${{ github.workspace }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # .NET 8 reicht laut deinen Angaben. Falls du später mehrere TFMs pflegst, kannst du 9.0 ergänzen.
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
           cache: true
-          # Wenn du Lockfiles verwendest, kannst du gezielt:
-          # cache-dependency-path: |
-          #   **/packages.lock.json
+          cache-dependency-path: |
+            Directory.Packages.props
+            **/*.csproj
 
-      # Optionaler zusätzlicher NuGet Cache (ergänzend – kann entfernt werden,
-      # wenn das eingebaute setup-dotnet Caching genügt).
-      - name: Cache NuGet packages (optional)
+      - name: Cache global packages and HTTP cache
         uses: actions/cache@v4
         with:
-          path: ~\AppData\Local\NuGet\Cache
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/packages.lock.json') }}
+          path: |
+            ~\\.nuget\\packages
+            ~\\AppData\\Local\\NuGet\\Cache
+            ~\\AppData\\Local\\NuGet\\v3-cache
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props', '**/*.csproj') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 
-      # (Optional) Falls du native Tools brauchst (CMake, Ninja, etc.)
-      # Aktiviere durch Setzen von if auf true oder entferne den Block.
-      - name: Install Native Tooling (optional)
-        if: ${{ false }}
-        run: |
-          choco install cmake --installargs '"ADD_CMAKE_TO_PATH=System"' -y
-          choco install ninja -y
-        shell: powershell
+      - name: Restore solution
+        run: dotnet restore VL.StandardLibs.sln --configfile NuGet.config --nologo
 
-      # (Optional) Git LFS – nur aktivieren falls du LFS Assets hast.
-      - name: Git LFS (optional)
-        if: ${{ false }}
-        shell: bash
-        run: |
-          git lfs install
-          git lfs pull
-
-      # Restore (mit Solution – passe Namen an falls abweichend)
-      - name: Restore
-        run: dotnet restore VL.StandardLibs.sln --nologo
-
-      # Optional: Lockfiles erzwingen, falls noch nicht committed (nur einmal nötig)
-      - name: Generate lock files (optional, einmalig)
-        if: ${{ false }}
-        run: dotnet restore VL.StandardLibs.sln --use-lock-file --force-evaluate
-
-      # Warm-Build Release (beschleunigt spätere Agent-Aktionen)
-      - name: Warm Build (Release)
+      - name: Build solution (Release)
         run: dotnet build VL.StandardLibs.sln -c Release --no-restore --nologo /m
 
-      # (Optional) Wenn Debug relevante Symbole später häufig gebraucht werden
-      - name: Warm Build (Debug) (optional)
-        if: ${{ false }}
+      - name: Build solution (Debug)
         run: dotnet build VL.StandardLibs.sln -c Debug --no-restore --nologo /m
 
-      # Warm-Testlauf – passe Filter an oder entferne ihn komplett
-      - name: Warm Test Run (fast subset)
+      - name: Run unit test projects (Release)
         run: |
-          dotnet test VL.StandardLibs.sln -c Release --no-build --logger "trx;LogFileName=warm.trx" --filter "TestCategory!=Slow"
+          $testProjects = @(
+            "VL.Core/tests/VL.Core.Tests.csproj",
+            "VL.Serialization.Raw/tests/VL.Serialization.Raw.Tests.csproj",
+            "VL.Serialization.MessagePack/tests/VL.Serialization.MessagePack.Tests.csproj"
+          )
 
-      # Beispiel für das Exportieren weiterer Env Variablen
-      - name: Export additional env
-        shell: bash
-        run: |
-          echo "GEOMETRY_OPT_LEVEL=avx2" >> $GITHUB_ENV
-          echo "SIMD_VECTOR_SIZE=256" >> $GITHUB_ENV
-          echo "INTEROP_STRICT_MODE=1" >> $GITHUB_ENV
+          foreach ($project in $testProjects) {
+            $name = [System.IO.Path]::GetFileNameWithoutExtension($project)
+            dotnet test $project -c Release --no-build --nologo --logger "trx;LogFileName=$name.trx"
+          }
 
-      # (Optional) Artefakte hochladen – normalerweise nicht nötig für den Copilot Agent
+      # Enable if the agent should collect build outputs for later steps.
       - name: Upload prebuilt artifacts (optional)
         if: ${{ false }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- align the Copilot warmup workflow with the VL.StandardLibs solution and central package management metadata
- add explicit caching of global NuGet packages and restore the solution before release/debug builds
- run the repository test projects individually so Copilot sessions start with fresh test results

## Testing
- `dotnet test VL.Core/tests/VL.Core.Tests.csproj -c Release` *(fails: The base path must be absolute. (Parameter 'basePath') on Linux runners)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d9d30004832a973eca333ab0165f